### PR TITLE
Python 3.7 support

### DIFF
--- a/NsoneObservium/__init__.py
+++ b/NsoneObservium/__init__.py
@@ -1,1 +1,1 @@
-from _version import __version__
+from ._version import __version__

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-
     ],
 
     keywords='observium network automation',  # Optional

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+
     ],
 
     keywords='observium network automation',  # Optional


### PR DESCRIPTION
Running in Python 3.7 results in a "ModuleNotFoundError" error. 
```
Traceback (most recent call last):
  File "python/observium/observium_login.py", line 2, in <module>
    from NsoneObservium.NsoneObservium import NsoneObservium
  File "/venv/lib/python3.7/site-packages/NsoneObservium/__init__.py", line 1, in <module>
    from _version import __version__
ModuleNotFoundError: No module named '_version'
```

Error discussed here: https://stackoverflow.com/questions/39130957/importerror-no-module-named-version-when-importing-mechanize

Tested backwards compatibility with Python2.7